### PR TITLE
Fixed deprecated set-output warning by upgrading to GITHUB_OUTPUT

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -42,4 +42,4 @@ runs:
 
     - id: set-output
       shell: bash
-      run: echo "::set-output name=version::$(b2 version)"
+      run: echo "version=$(b2 version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This small pull request removes the deprecation warnings on set-output.  GitHub now uses GITHUB_OUTPUT instead.  See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for details.

This can be released as a patch releases v1.0.1. The change is backwards compatible.  No one upgrading needs to make any changes on their end.