### PR TITLE
Change to new account authorize cli syntax

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
     - id: set-credentials
       shell: bash
       if: ${{ env.B2_APPLICATION_KEY_ID && env.B2_APPLICATION_KEY }}
-      run: b2 authorize-account "${B2_APPLICATION_KEY_ID}" "${B2_APPLICATION_KEY}"
+      run: b2 account authorize "${B2_APPLICATION_KEY_ID}" "${B2_APPLICATION_KEY}"
 
     - id: set-output
       shell: bash


### PR DESCRIPTION
Old cli command ` b2 authorize-account` is deprecated, new one is  `b2 account authorize`